### PR TITLE
fix: downgrade husky to allow node@6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,36 @@ npm install @clearpeaks/code-linting-style --save-dev
 
 ## Git Hook
 
-In package.json, inside of npm scripts, add the following hook to run prettier and tslint before each commit
+In package.json, at scripts level, add the following hook to run prettier and linter before each commit
 
 ```
-"precommit": "pretty-quick --staged && tslint -c ./tslint.json 'src/**/*.ts'"
+{
+  "scripts": {
+    ...
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged && tslint -c ./tslint.json 'src/**/*.ts'"
+    }
+  }
+}
 ```
+
+#### Deprecarion warning. Upgrading from 0.14
+With the version `0` the precommit hook was being declared inside of the scripts. Please change that logic on your projects.
+```
+{
+  "scripts": {
+    "precommit": "pretty-quick --staged && tslint -c ./tslint.json 'src/**/*.ts'"   // Before (BAD)
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged && tslint -c ./tslint.json 'src/**/*.ts'"    // Now (GOOD)
+    }
+  }
+}
+```
+Note: Version 1 of husky require node version >=6, while Husky 2 require node>=8, so we are keeping husky 1 for compatibility.
 
 ## Tslint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,12 +145,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "@types/normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-      "dev": true
-    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -721,9 +715,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -768,21 +762,21 @@
       "dev": true
     },
     "husky": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-2.4.0.tgz",
-      "integrity": "sha512-3k1wuZU20gFkphNWMjh2ISCFaqfbaLY7R9FST2Mj9HeRhUK9ydj9qQR8qfXlog3EctVGsyeilcZkIT7uBZDDVA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-1.3.1.tgz",
+      "integrity": "sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^5.2.0",
+        "cosmiconfig": "^5.0.7",
         "execa": "^1.0.0",
         "find-up": "^3.0.0",
-        "get-stdin": "^7.0.0",
+        "get-stdin": "^6.0.0",
         "is-ci": "^2.0.0",
-        "pkg-dir": "^4.1.0",
+        "pkg-dir": "^3.0.0",
         "please-upgrade-node": "^3.1.1",
-        "read-pkg": "^5.1.1",
+        "read-pkg": "^4.0.1",
         "run-node": "^1.0.0",
-        "slash": "^3.0.0"
+        "slash": "^2.0.0"
       }
     },
     "iconv-lite": {
@@ -1213,42 +1207,19 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
     "pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "requires": {
-        "find-up": "^4.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.0.0.tgz",
-          "integrity": "sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        }
+        "find-up": "^3.0.0"
       }
     },
     "please-upgrade-node": {
@@ -1407,15 +1378,14 @@
       "dev": true
     },
     "read-pkg": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.1.1.tgz",
-      "integrity": "sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+      "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
       "dev": true,
       "requires": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
+        "normalize-package-data": "^2.3.2",
         "parse-json": "^4.0.0",
-        "type-fest": "^0.4.1"
+        "pify": "^3.0.0"
       }
     },
     "reflect-metadata": {
@@ -1528,9 +1498,9 @@
       "dev": true
     },
     "slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
     },
     "slice-ansi": {
@@ -1820,12 +1790,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-fest": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
-      "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
-      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearpeaks/code-linting-style",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A TSLint and Prettier config for ClearPeaks",
   "main": "index.js",
   "scripts": {
@@ -10,15 +10,15 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "husky": "^2.4.0",
+    "babel-eslint": "^10.0.1",
+    "eslint": "^5.16.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "husky": "^1.3.1",
+    "prettier": "1.18.2",
     "pretty-quick": "^1.11.0",
     "tslint": "^5.17.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-eslint-rules": "^5.4.0",
-    "tslint-microsoft-contrib": "^6.2.0",
-    "babel-eslint": "^10.0.1",
-    "eslint": "^5.16.0",
-    "eslint-plugin-prettier": "^3.1.0",
-    "prettier": "1.18.2"
+    "tslint-microsoft-contrib": "^6.2.0"
   }
 }


### PR DESCRIPTION
### What this PR do?
Downgrade husky to version 1 to keep compatibility with node 6
### Why are we doing this? Any context or related work?
Husky 2 require node 8, which disable the hooks for the projects using node6 
### Summary of changes
Updated Readme to specify the required migration on the hooks.