### PR TITLE
feat: include rule to detect used functions not declared

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,7 @@ module.exports = {
     "camelcase": ["error", { "properties": "never" }],
     "no-console": ["error", { "allow": ["warn", "error", "debug"] }],
     "no-debugger": "error",
-    "no-unused-vars": ["error", { "args": "after-used" }]
+    "no-unused-vars": ["error", { "args": "after-used" }],
+    "no-undef": "error"
   }
 }

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ module.exports = {
 }
 ```
 
+Note: I had to use the following hook to make the precommit work
+```
+  "husky": {
+    "hooks": {
+      "pre-commit": "./node_modules/.bin/pretty-quick --staged && ./node_modules/.bin/eslint --ext .js lib/ --fix"
+    }
+  },
+```
+Installing some extra packages `npm i -D eslint eslint-config-prettier husky prettier pretty-quick`
 You can find more info about eslint rules [here](https://eslint.org/docs/rules/)
 
 ## Tips

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearpeaks/code-linting-style",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "description": "A TSLint and Prettier config for ClearPeaks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### What this PR does?
For `eslint` (being used in js projects), adds an important missing rule: `"no-undef": "error"`
This rule generates an error when you try to use a function that is not defined. It is important to avoid typos while developing.